### PR TITLE
Add support for English subtitles only mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -143,6 +143,20 @@
   cursor: pointer;
 }
 
+.english-only-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #e0e0e0;
+}
+
+.english-only-switch {
+  width: 2.6rem;
+  height: 1.4rem;
+  cursor: pointer;
+}
+
 .dual-sub-extension-section_rewind_tooltip,
 .dual-sub-extension-section_forward_tooltip,
 .dual-sub-extension-section_settings_tooltip {


### PR DESCRIPTION
The dual-sub control bar now includes a second, matching switch labeled “EN only” that becomes active whenever dual subtitles are on and lets viewers hide the Finnish line while keeping the translated English text visible. Toggling it simply updates the rendered overlay without any extra buttons or popovers.